### PR TITLE
Fixes bug leaving file presenter installed after ULDocument closes

### DIFF
--- a/Source/ULDocument.m
+++ b/Source/ULDocument.m
@@ -645,6 +645,7 @@ NSString *ULDocumentUnhandeledSaveErrorNotificationErrorKey			= @"error";
 
 - (void)close
 {
+	[_presenter endPresentation];
 	_presenter = nil;
 	
 	// Deactivate autosave observers. Do it on _autosaveQueue to prevent race conditions.

--- a/Tests/ULDocumentTest.m
+++ b/Tests/ULDocumentTest.m
@@ -1357,6 +1357,25 @@ NSString *kTestText3	= @"Fusce tincidunt erat sit amet magna porttitor nec iacul
 	XCTAssertEqualObjects(documentReadOnly.fileModificationDate, fileChange, @"Change date should not change");
 }
 
+- (void)testClosedDocumentsShouldRemoveFilePresentersFromNSFileCoordinator {
+	NSURL *url = [self createTestDocument];
+
+	ULTestDocument *document = [[ULTestDocument alloc] initWithFileURL:url readOnly:NO];
+	XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+	[document openWithCompletionHandler:^(BOOL success) {
+		XCTAssertTrue([NSFileCoordinator filePresenters].count == 1);
+		XCTAssertTrue(success, @"Can't open document");
+	}];
+
+	[document closeWithCompletionHandler:^(BOOL success) {
+		XCTAssertTrue([NSFileCoordinator filePresenters].count == 0, @"File presenter not removed.");
+		[expectation fulfill];
+	}];
+
+	[self waitForExpectationsWithTimeout:2 handler:^(NSError * _Nullable error) {
+		NSLog(@"Error waiting for expectation: %@", error);
+	}];
+}
 
 #if !TARGET_OS_IPHONE
 - (void)testVersionPreservation

--- a/ULDocument.xcodeproj/project.pbxproj
+++ b/ULDocument.xcodeproj/project.pbxproj
@@ -535,7 +535,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "Tests/Other/ULDocumentTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				TEST_HOST = "";
@@ -556,7 +556,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Source/Other/ULDocument-iOS-Prefix.pch";
 				INFOPLIST_FILE = "Tests/Other/ULDocumentTests-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				TEST_HOST = "";


### PR DESCRIPTION
Hopefully, this one line PR will be merged🤞. 

Prior to this, the _presenter variable was being set to nil prior to `endPresentation` being called. Later, when the ULDocument instance was deallocated, it tried to call `endPresentation`, but had no effect since the `_presenter` var was already set to nil. The result was that the presenter proxy instance was left in the `+[NSFileCoordinator filePresenters]` array. Ultimately this can lead to an iOS app being terminated by iOS when the app is suspended due to background inactivity.

FYI, had to update the base SDK version in the test project to get it to run.